### PR TITLE
Update to AWS CLI v1.11.68

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER maintainers@codeship.com
 
 # which version of the AWS CLI to install.
 # https://pypi.python.org/pypi/awscli
-ARG AWS_CLI_VERSION="1.11.41"
+ARG AWS_CLI_VERSION="1.11.68"
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=true
 


### PR DESCRIPTION
This is required to run the latest aws cloudformation package and deploy methods.