### PR TITLE
updates awscli and adds no-email flag

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER maintainers@codeship.com
 
 # which version of the AWS CLI to install.
 # https://pypi.python.org/pypi/awscli
-ARG AWS_CLI_VERSION="1.11.85"
+ARG AWS_CLI_VERSION="1.11.91"
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=true
 

--- a/dockercfg-generator/aws_docker_creds.sh
+++ b/dockercfg-generator/aws_docker_creds.sh
@@ -34,7 +34,7 @@ fi
 
 # fetching aws docker login
 echo "Logging into AWS ECR"
-$(aws ecr get-login)
+$(aws ecr get-login --no-include-email)
 
 # writing aws docker creds to desired path
 echo "Writing Docker creds to $1"


### PR DESCRIPTION
With 17.06 there will be a breaking change and `docker login` will not contain the `-e` flag for email again. Thus the new AWS CLI version allows for getting the login without the email flag, which is what this PR is introducing.