### PR TITLE
Kubectl and heptio-authenticator-aws binaries

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -12,15 +12,14 @@ RUN \
     py-pip \
     && pip install virtualenv
 
-
-# https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-binary-via-curl
-ARG KUBECTL_VERSION="v1.9.0"
-RUN curl -L "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" > /usr/local/bin/kubectl \
-    && chmod +x /usr/local/bin/kubectl
+# https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html#get-started-kubectl
+ARG KUBECTL_VERSION="1.10.3"
+ARG KUBECTL_BUILD_DATE="2018-06-05"
+RUN curl -L https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_VERSION}/${KUBECTL_BUILD_DATE}/bin/linux/amd64/kubectl > /usr/local/bin/kubectl \
+  && chmod +x /usr/local/bin/kubectl
 
 RUN virtualenv root/.codeship-venv
 
 ENV CODESHIP_VIRTUALENV="/root/.codeship-venv"
 
 COPY scripts/ /usr/bin/
-

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -17,6 +17,8 @@ ARG KUBECTL_VERSION="1.10.3"
 ARG KUBECTL_BUILD_DATE="2018-06-05"
 RUN curl -L https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_VERSION}/${KUBECTL_BUILD_DATE}/bin/linux/amd64/kubectl > /usr/local/bin/kubectl \
   && chmod +x /usr/local/bin/kubectl
+RUN curl -L https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_VERSION}/${KUBECTL_BUILD_DATE}/bin/linux/amd64/heptio-authenticator-aws > /usr/local/bin/heptio-authenticator-aws \
+  && chmod +x /usr/local/bin/heptio-authenticator-aws
 
 RUN virtualenv root/.codeship-venv
 


### PR DESCRIPTION
I've EKS cluster and Codeship Pro CI/CD pipeline.

Initially I've tried to connect to the cluster using `kubectl` binary provided in `codeship/aws-deployment ` image; build hanged up for 20 minutes and I stopped it manually.

After that I've created custom image with `kubectl` and `heptio-authenticator-aws` binaries suggested by EKS user guide - `kubectl` now works like charm and I can run commands against my cluster as a part of Codeship build. I guess I'm not the only EKS user here and everyone will benefit from a better AWS deployment image.

EKS user guide:  https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html#get-started-kubectl 