### PR TITLE
Adding aws-iam-authenticator to support EKS deployments

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -13,12 +13,15 @@ RUN \
     && pip install virtualenv
 
 
-# https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-binary-via-curl
-ARG KUBECTL_VERSION="v1.9.0"
-RUN curl -L "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" > /usr/local/bin/kubectl \
+# install kubectl from AWS
+ARG KUBECTL_VERSION="1.10.3"
+ARG KUBECTL_BUILD_DATE="2018-07-26"
+
+RUN curl -L https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_VERSION}/${KUBECTL_BUILD_DATE}/bin/linux/amd64/kubectl > /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 
-RUN curl -L "https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator" > /usr/local/bin/aws-iam-authenticator \
+# install aws-iam-authenticator
+RUN curl -L "https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_VERSION}/${KUBECTL_BUILD_DATE}/bin/linux/amd64/aws-iam-authenticator" > /usr/local/bin/aws-iam-authenticator \
     && chmod +x /usr/local/bin/aws-iam-authenticator
 
 RUN virtualenv root/.codeship-venv

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -18,6 +18,9 @@ ARG KUBECTL_VERSION="v1.9.0"
 RUN curl -L "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" > /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 
+RUN curl -L "https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator" > /usr/local/bin/aws-iam-authenticator \
+    && chmod +x /usr/local/bin/aws-iam-authenticator
+
 RUN virtualenv root/.codeship-venv
 
 ENV CODESHIP_VIRTUALENV="/root/.codeship-venv"


### PR DESCRIPTION
Use AWS IAM tools to authenticate to a Kubernetes cluster running in AWS.
https://github.com/kubernetes-sigs/aws-iam-authenticator
Required for deployments to AWS EKS.