### PR TITLE
Take only first 512 characters for description

### DIFF
--- a/deployment/scripts/codeship_aws_codedeploy_deploy
+++ b/deployment/scripts/codeship_aws_codedeploy_deploy
@@ -26,11 +26,13 @@ else
   S3_PATH="s3://$S3_BUCKET/$S3_BUCKET_SUBFOLDER_PATH/$FILE_NAME"
 fi
 
-aws deploy push --application-name "$APPLICATION_NAME" --description "$CI_COMMIT_MESSAGE" --ignore-hidden-files --s3-location "$S3_PATH" --source "$APPLICATION_FOLDER" > /dev/null
+DESCRIPTION="${CI_COMMIT_MESSAGE:0:512}"
+
+aws deploy push --application-name "$APPLICATION_NAME" --description "$DESCRIPTION" --ignore-hidden-files --s3-location "$S3_PATH" --source "$APPLICATION_FOLDER" > /dev/null
 
 echo "Creating new Deployment: $VERSION_NAME"
 
-deployment=("--application-name" "$APPLICATION_NAME" "--deployment-group-name" "$DEPLOYMENT_GROUP_NAME" "--description" "$CI_COMMIT_MESSAGE" "--s3-location" "bucket=$S3_BUCKET,key=$S3_KEY,bundleType=zip")
+deployment=("--application-name" "$APPLICATION_NAME" "--deployment-group-name" "$DEPLOYMENT_GROUP_NAME" "--description" "$DESCRIPTION" "--s3-location" "bucket=$S3_BUCKET,key=$S3_KEY,bundleType=zip")
 
 if [ ! -z "$DEPLOYMENT_CONFIG_NAME" ]; then
   deployment+=("--deployment-config-name" "$DEPLOYMENT_CONFIG_NAME")


### PR DESCRIPTION
We've encountered this error in production:
![image](https://user-images.githubusercontent.com/5065625/48281191-af7fe300-e40a-11e8-91e1-5e2f9630fc08.png)

It turned out that AWS CodeDeploy has a restrition on descripton where the max length is 512 characters, which is kind of documented [here](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_RegisterApplicationRevision.html)
