### PR TITLE
[URGENT BUG] - Updating AWS CLI to v1.19.69 and fixing deprecated get-login function.

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 # which version of the AWS CLI to install.
 # https://pypi.python.org/pypi/awscli
-ARG AWS_CLI_VERSION="1.16.250"
+ARG AWS_CLI_VERSION="1.19.69"
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=true
 

--- a/dockercfg-generator/aws_docker_creds.sh
+++ b/dockercfg-generator/aws_docker_creds.sh
@@ -32,14 +32,16 @@ if [[ -n $AWS_STS_ROLE || -n $AWS_STS_ACCOUNT ]]; then
   export AWS_SESSION_EXPIRATION=$(cat ${aws_tmp} | jq -r ".Credentials.Expiration")
 fi
 
-registry_id=''
-if [[ -n $AWS_ECR_REGISTRY_IDS ]]; then
-  registry_ids="--registry-ids $AWS_ECR_REGISTRY_IDS"
-fi
+# registry_id=''
+# if [[ -n $AWS_ECR_REGISTRY_IDS ]]; then
+#   registry_ids="--registry-ids $AWS_ECR_REGISTRY_IDS"
+# fi
 
 # fetching aws docker login
 echo "Logging into AWS ECR"
-$(aws ecr get-login --no-include-email ${registry_ids})
+# AWS has deprecated the get-login function in favor of get-login-password
+# https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html
+$(aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${AWS_STS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com)
 
 # writing aws docker creds to desired path
 echo "Writing Docker creds to $1"


### PR DESCRIPTION
When attempting to generate a dockercfg using the codeship/aws-ecr-dockercfg image you will end up getting an EOF response from AWS ECR. I've bumped the AWS CLI to the latest version available via PyPi but AWS CLI v2 support would be ideal.

`docker run -it -v /Users/CENSORED/data:/opt/data --env-file=aws.env -v /var/run/docker.sock:/var/run/docker.sock codeship/aws-ecr-dockercfg-generator /opt/data/aws.dockercfg  
AWS ECR dockercfg generator
Using STS to get credentials for arn:aws:iam::CENSORED:role/CENSORED_ROLE
Logging into AWS ECR
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /root/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
Writing Docker creds to /opt/data/aws.dockercfg`

The generated credentials will not work and you will receive the following error:
`{"topic":{"subject":"step","type":"finished"},"err":{"Status":400,"Message":"Bad parameters and missing X-Registry-Auth: EOF"},"attributes":{"step":"push_images_push_app_to_staging_latest","type":"push"}}
{"topic":{"subject":"step","type":"finished"},"err":[{"Status":400,"Message":"Bad parameters and missing X-Registry-Auth: EOF"}],"attributes":{"step":"push_images","type":"serial"}}
`

This bug appears to be due to the `get-login` function being deprecated as mentioned in the following doc:
 https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html

Using the new `get-login-password` function instead allows a successful upload to ECR without issue.