### PR TITLE
Update to AWS CLI 1.19.89

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer='Codeship Inc., <maintainers@codeship.com>'
 
 # which version of the AWS CLI to install.
 # https://pypi.python.org/pypi/awscli
-ARG AWS_CLI_VERSION="1.19.70"
+ARG AWS_CLI_VERSION="1.19.89"
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=true
 

--- a/dockercfg-generator/README.md
+++ b/dockercfg-generator/README.md
@@ -35,9 +35,6 @@ Optionally, you can also set the following variables to assume a role across acc
 * `AWS_STS_ROLE` - The AWS role to assume
 * `AWS_STS_ACCOUNT` - The AWS account the role exists in
 
-If you are using an ECR registry in another AWS account to the IAM user but you aren't using a role, a list of AWS account IDs that correspond to the registries that you want to log in to can be specified:
-* `AWS_ECR_REGISTRY_IDS` - A space separated list of AWS account IDs
-
 Here is an example of using and ECR Dockercfg generator to authenticate pushing an image.
 
 ```yaml


### PR DESCRIPTION
Also removes `AWS_ECR_REGISTRY_IDS` documentation related to https://github.com/codeship-library/aws-utilities/pull/107