### PR TITLE
region specific endpoint for ecr-public login

### DIFF
--- a/dockercfg-generator/aws_docker_creds.sh
+++ b/dockercfg-generator/aws_docker_creds.sh
@@ -39,18 +39,18 @@ fi
 
 # For public images stored in public.ecr.aws, we need to use a different CLI call
 if [[ -v ECR_PUBLIC ]]; then
-  COMMAND=ecr-public
   SERVER=public.ecr.aws
+  CREDS=$(aws ecr-public get-login-password --region=us-east-1)
 else
-  COMMAND=ecr
   SERVER=${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
+  CREDS=$(aws ecr get-login-password --region=${AWS_REGION})
 fi
 
 # fetching aws docker login
 # aws deprecated the get-login function in favor of get-login-password
 # https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login.html
 echo "Logging into AWS ECR with account ${AWS_ACCOUNT}"
-aws ${COMMAND} get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin ${SERVER}
+echo ${CREDS} | docker login --username AWS --password-stdin ${SERVER}
 
 # writing aws docker creds to desired path
 echo "Writing Docker creds to $1"


### PR DESCRIPTION
Hi,

When trying to setup automated build to ecr-public I was encountering this error during the docker login:

```
An error occurred (UnsupportedCommandException) when calling the GetAuthorizationToken operation: GetAuthorizationToken command is only supported in us-east-1.
```

This updates the ecr-public call to use a specific region, which solved my problem.

Cheers